### PR TITLE
Split up coverage publication so it can work with PR's from fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,15 +72,19 @@ jobs:
       - name: Run the client test
         run: just client
 
-      - name: Archive test artifacts
-        uses: actions/upload-artifact@v4
+      - name: Save PR number and coverage results
+        run: |
+          mkdir -p ./test-results-artifact
+          mkdir -p ./test-results-artifact/load-test
+          echo ${{ github.event.number }} > ./test-results-artifact/PR-number.txt
+          cp api/test/output/pytest-coverage.txt ./test-results-artifact/datastore-pytest-coverage.txt
+          cp api/test/output/pytest.xml ./test-results-artifact/datastore-pytest.xml
+          cp datastore/load-test/output/store_read_*.csv ./test-results-artifact/load-test
+          cp datastore/load-test/output/store_rw_*.csv ./test-results-artifact/load-test
+      - uses: actions/upload-artifact@v4
         with:
           name: test-results-artifact
-          path: |
-            api/test/output/pytest-coverage.txt
-            api/test/output/pytest.xml
-            datastore/load-test/output/store_read_*.csv
-            datastore/load-test/output/store_rw_*.csv
+          path: test-results-artifact/
 
       - name: Print results
         run: |
@@ -123,46 +127,17 @@ jobs:
       - name: Run the unit test
         run: just ingest-unit
 
-      - name: Archive test artifacts
-        uses: actions/upload-artifact@v4
+      - name: Save PR number and coverage results
+        run: |
+          mkdir -p ./ingest-test-results-artifact
+          mkdir -p ./ingest-test-results-artifact/load_test
+          cp ingest/test/output/pytest-coverage.txt ./ingest-test-results-artifact/ingest-pytest-coverage.txt
+          cp ingest/test/output/pytest.xml ./ingest-test-results-artifact/ingest-pytest.xml
+      - uses: actions/upload-artifact@v4
         with:
           name: ingest-test-results-artifact
-          path: |
-            ingest/test/output/pytest-coverage.txt
-            ingest/test/output/pytest.xml
+          path: ingest-test-results-artifact/
 
       - name: Cleanup
         if: always()
         run: just destroy
-
-  publish-test-results:
-    needs:
-      - test-datastore
-      - test-ingest
-    runs-on: ubuntu-latest
-    if: github.event_name != 'push' || github.event.ref_type != 'tag'
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
-    steps:
-      - name: Download test-datastore results so that they can be published
-        uses: actions/download-artifact@v4
-        with:
-          name: test-results-artifact
-          path: ./artifacts/test-results
-
-      - name: Download test-ingest results so that they can be published
-        uses: actions/download-artifact@v4
-        with:
-          name: ingest-test-results-artifact
-          path: ./artifacts/ingest-results
-
-      - name: Comment coverage
-        uses: MishaKav/pytest-coverage-comment@main
-        with:
-          title: Unit Test Coverage Report
-          pytest-coverage-path: ./artifacts/test-results/api/test/output/pytest-coverage.txt
-          multiple-files: |
-            API Unit Tests, ./artifacts/test-results/api/test/output/pytest-coverage.txt, ./artifacts/test-results/api/test/output/pytest.xml
-            Ingest Unit Tests, ./artifacts/ingest-results/pytest-coverage.txt, ./artifacts/ingest-results/pytest.xml

--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -1,0 +1,63 @@
+name: Comment coverage report on the pull request
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  post-coverage-report:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: 'Download artifacts'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+
+            var matchDatastoreArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "test-results-artifact"
+            })[0];
+            var download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchDataStoreArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/test-results-artifact.zip', Buffer.from(download.data));
+
+            var matchIngestArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "ingest-test-results-artifact"
+            })[0];
+            var download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchIngestArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/ingest-test-results-artifact', Buffer.from(download.data));
+      - name: Unzip datastore artifacts
+        run: unzip test-results-artifact.zip
+      - name: Unzip ingest artifacts
+        run: unzip ingest-test-results-artifact.zip
+      - name: Read the PR number from file
+        id: pr_number
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./PR-number.txt
+      - name: Publish pytest coverage as comment
+        uses: MishaKav/pytest-coverage-comment@main
+        with:
+          issue-number: ${{ steps.pr_number.outputs.content }}
+          multiple-files: |
+            API Unit Tests, ./datastore-pytest-coverage.txt, ./datastore-pytest.xml
+            Ingest Unit Tests, ./ingest-pytest-coverage.txt, ./ingest-pytest.xml


### PR DESCRIPTION
This is based on this example:
https://github.com/MishaKav/pytest-coverage-comment/pull/153

This should work, but can only be tested when it is merged, because:
`This event will only trigger a workflow run if the workflow file exists on the default branch.`
See: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run