### PR TITLE
Replace query by one that performs better by 30-40%.

### DIFF
--- a/datastore/datastore/storagebackend/postgresql/getlocations.go
+++ b/datastore/datastore/storagebackend/postgresql/getlocations.go
@@ -36,7 +36,7 @@ func getLocs(
 
 	// define and execute query
 	query := fmt.Sprintf(`
-		SELECT DISTINCT ON (platform, parameter_name)
+		SELECT DISTINCT ON (ts_id)
 			point,
 			platform,
 			platform_name,
@@ -45,7 +45,7 @@ func getLocs(
 		JOIN time_series on observation.ts_id = time_series.id
 		JOIN geo_point ON observation.geo_point_id = geo_point.id
 		WHERE %s AND %s AND %s AND %s
-		ORDER BY platform, parameter_name, obstime_instant DESC
+		ORDER BY ts_id, obstime_instant DESC;
 		`,
 		timeFilter,
 		geoFilter,
@@ -112,6 +112,7 @@ func getLocs(
 	// add result items sorted on platform
 	for _, platform := range slices.Sorted(maps.Keys(pformInfos)) {
 		pformInfo := pformInfos[platform]
+		slices.Sort(*pformInfo.paramNames)
 		point := getRepresentativePoint(pformInfo.points)
 		locs = append(locs, &datastore.LocMetadata{
 			GeoPoint: &datastore.Point{


### PR DESCRIPTION
When comparing the new GetLocations code with the code on `main`, I noticed that the `/locations` endpoint on `main` used to take about 100-125 ms for the default test dataset (the one you get with `just load`), and with the new code it is actually slower (around 330 ms).

I looked into this, and managed to get the time down to about 200 ms by a simple change to the query, which brings it more in line with the query that datastore used to do for the `/locations` endpoint.

Compared to `main` both the `issue_107` and the `loc_query` have signifcantly lower traffic between the API and the datastore. For example, for the Netatmo data, it goes down from 24MB to 8MB.

So overall, I think this is still an improvement.