### PR TITLE
Fix settings of MQTT topic prepend

### DIFF
--- a/ingest/api/send_mqtt.py
+++ b/ingest/api/send_mqtt.py
@@ -6,8 +6,7 @@ from fastapi import HTTPException
 
 logger = logging.getLogger(__name__)
 
-if "MQTT_TOPIC_PREPEND" in os.environ:
-    mqtt_topic_prepend = os.getenv("MQTT_TOPIC_PREPEND", "")
+mqtt_topic_prepend = os.getenv("MQTT_TOPIC_PREPEND", "")
     if not mqtt_topic_prepend or mqtt_topic_prepend == "/":
         mqtt_topic_prepend = ""
         logger.error(

--- a/ingest/api/send_mqtt.py
+++ b/ingest/api/send_mqtt.py
@@ -8,15 +8,12 @@ logger = logging.getLogger(__name__)
 
 if "MQTT_TOPIC_PREPEND" in os.environ:
     mqtt_topic_prepend = os.getenv("MQTT_TOPIC_PREPEND", "")
-    if mqtt_topic_prepend and not mqtt_topic_prepend.endswith("/") and len(mqtt_topic_prepend) > 1:
-        mqtt_topic_prepend = mqtt_topic_prepend + "/"
-    else:
+    if not mqtt_topic_prepend or mqtt_topic_prepend == "/":
         mqtt_topic_prepend = ""
         logger.error(
-            "MQTT_TOPIC_PREPEND cannot be just a '/' and can not be empty. Setting topic prepend to empty string."
-        )
-else:
-    mqtt_topic_prepend = ""
+            "MQTT_TOPIC_PREPEND cannot be just a '/'. Setting topic prepend to empty string."
+    else:
+        mqtt_topic_prepend = mqtt_topic_prepend if mqtt_topic_prepend.endswith("/") else mqtt_topic_prepend + "/"
 
 
 def connect_mqtt(mqtt_conf: dict):

--- a/ingest/api/send_mqtt.py
+++ b/ingest/api/send_mqtt.py
@@ -8,7 +8,15 @@ logger = logging.getLogger(__name__)
 
 if "MQTT_TOPIC_PREPEND" in os.environ:
     mqtt_topic_prepend = os.getenv("MQTT_TOPIC_PREPEND", "")
-    mqtt_topic_prepend = mqtt_topic_prepend if mqtt_topic_prepend.endswith("/") else mqtt_topic_prepend + "/"
+    if mqtt_topic_prepend and not mqtt_topic_prepend.endswith("/") and len(mqtt_topic_prepend) > 1:
+        mqtt_topic_prepend = mqtt_topic_prepend + "/"
+    else:
+        mqtt_topic_prepend = ""
+        logger.error(
+            "MQTT_TOPIC_PREPEND cannot be just a '/' and can not be empty. Setting topic prepend to empty string."
+        )
+else:
+    mqtt_topic_prepend = ""
 
 
 def connect_mqtt(mqtt_conf: dict):

--- a/ingest/api/send_mqtt.py
+++ b/ingest/api/send_mqtt.py
@@ -7,12 +7,11 @@ from fastapi import HTTPException
 logger = logging.getLogger(__name__)
 
 mqtt_topic_prepend = os.getenv("MQTT_TOPIC_PREPEND", "")
-    if not mqtt_topic_prepend or mqtt_topic_prepend == "/":
-        mqtt_topic_prepend = ""
-        logger.error(
-            "MQTT_TOPIC_PREPEND cannot be just a '/'. Setting topic prepend to empty string."
-    else:
-        mqtt_topic_prepend = mqtt_topic_prepend if mqtt_topic_prepend.endswith("/") else mqtt_topic_prepend + "/"
+if not mqtt_topic_prepend or mqtt_topic_prepend == "/":
+    mqtt_topic_prepend = ""
+    logger.error("MQTT_TOPIC_PREPEND cannot be just a '/'. Setting topic prepend to empty string.")
+else:
+    mqtt_topic_prepend = mqtt_topic_prepend if mqtt_topic_prepend.endswith("/") else mqtt_topic_prepend + "/"
 
 
 def connect_mqtt(mqtt_conf: dict):


### PR DESCRIPTION
Closes #273
This PR fixes some edge case for settings the MQTT topic prepend that resulted in invalid MQTT topics or the server beeing unable to start.